### PR TITLE
Fixed infinite timers

### DIFF
--- a/rpgs/server/jobs/polizei-server.lua
+++ b/rpgs/server/jobs/polizei-server.lua
@@ -653,7 +653,7 @@ function updatePlayerCabin()
 		end
 	end
 end
-setTimer(updatePlayerCabin, 60000, -1)
+setTimer(updatePlayerCabin, 60000, 0)
 
 
 

--- a/rpgs/server/vehicles-server.lua
+++ b/rpgs/server/vehicles-server.lua
@@ -66,7 +66,7 @@ function createRPGVehicle(model,x,y,z,rz,name,color,temp,eingepackt)
 end
 
 function loadAllRootRPGVehicles()
-	setTimer(benzinVerbrauch, 60000*5, -1)
+	setTimer(benzinVerbrauch, 60000*5, 0)
 	
 	if mysql_ping ( g_mysql["connection"] ) == false then
 		onResourceStopMysqlEnd()


### PR DESCRIPTION
-1 results in 0xFFFFFFFF (= 2^32-1) instead of an infinite timer and is therefore a warning since MTA 1.5
